### PR TITLE
[MAINT] add requirements.txt and pin docutils version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Documentation Status](https://readthedocs.org/projects/simexp-documentation/badge/?version=latest)](https://simexp-documentation.readthedocs.io/en/latest/?badge=latest)
+
 # SIMEXP-Documentation
 
 https://simexp-documentation.readthedocs.io/en/latest/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-rtd-theme
+recommonmark
+docutils<0.18


### PR DESCRIPTION
Add `requirements.txt` and attempt to pin `docutils` to 0.17 to avoid bug introduced from 0.18